### PR TITLE
implemented \total* and \subtotal* to calculate totals and subtotals automatically

### DIFF
--- a/outn.cls
+++ b/outn.cls
@@ -11,6 +11,7 @@
 \DeclareOption{specsolns}{%
   \@specsolnstrue
 }
+
 \ProcessOptions\relax
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Load packages/class file
@@ -246,14 +247,31 @@
   \newcommand{\subtotal}[2][\unskip]{\relax}
   \newenvironment{longremark}{\comment}{\endcomment}
 \else
-  \newcommand{\bracketedmarks}[1]{\marginnote{\hfill[\textsl{#1}]\hspace*{4cm}}}
-  \newcommand{\solnmarks}[1]{\marginnote{\hfill\small #1\hspace*{4cm}}}
-  \newcommand{\solnmarksplus}[2]{\marginnote{\hfill\small \makebox[1cm][r]{#1}\makebox[4cm][r]{\parbox[t]{3.75cm}{\raggedright #2}}}}
+  \newcounter{total}[question]
+  \newcounter{subtotal}[question]
+  \newcommand{\@update@totals}[1]{%
+     \addtocounter{subtotal}{#1}%
+     \addtocounter{total}{#1}%
+  }
+  \newcommand{\bracketedmarks}[1]{\marginnote{\hfill[\textsl{#1}]\hspace*{4cm}}\@update@totals{#1}}
+  \newcommand{\solnmarks}[1]{\marginnote{\hfill\small #1\hspace*{4cm}}\@update@totals{#1}}
+  \newcommand{\solnmarksplus}[2]{\marginnote{\hfill\small \makebox[1cm][r]{#1}\makebox[4cm][r]{\parbox[t]{3.75cm}{\raggedright #2}}}\@update@totals{#1}}
+  \def\total{\@ifstar\@total\@@total}
+  \def\subtotal{\@ifstar\@subtotal\@@subtotal}
   \newcommand{\remark}[1]{\emph{Remark:} #1}
-  \newcommand{\total}[2][\unskip]{\marginnote{\bfseries \makebox[1cm][r]{#2}\ Total\ #1}}
-  \newcommand{\subtotal}[2][\unskip]{\marginnote{\small\bfseries \makebox[1cm][r]{#2}\ Subtotal\ #1}}
   \newenvironment{longremark}{\emph{Remarks:}\par}{}
 \fi
+
+% \total*
+\newcommand{\@total}[1][\unskip]{\marginnote{\bfseries \makebox[1cm][r]{\thetotal}\ Total\ #1}}
+% \total[]{}
+\newcommand{\@@total}[2][\unskip]{\marginnote{\bfseries \makebox[1cm][r]{#2}\ Total\ #1}}
+% \subtotal*
+\newcommand{\@subtotal}[1][\unskip]{\marginnote{\small\bfseries \makebox[1cm][r]{\thesubtotal}\ Subtotal\ #1 }\setcounter{subtotal}{0}}
+% \subtotal[]{}
+\newcommand{\@@subtotal}[2][\unskip]{\marginnote{\small\bfseries \makebox[1cm][r]{#2}\ Subtotal\ #1}\setcounter{subtotal}{0}}
+
+
 %
 \def\marks{\solnmarks}
 \def\mk{\solnmarks}

--- a/tntemplate.tex
+++ b/tntemplate.tex
@@ -123,6 +123,17 @@ Emulate the OUTeX intertext command using the (built-in) enumitem command.
 \end{solution}
 \total{3}
 
+\question{10}
+\begin{enumerate}
+  \item Subtotals can be calculated automatically using \verb!\subtotal*! 
+    or \verb!\subtotal*[comment]! \mk 2 
+  \item Totals can be calculated automatically using  \verb!\total*! 
+    or \verb!\total*[comment]! \mk 3
+\end{enumerate}
+\subtotal*
+\bigskip
+\total*
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \cma*{41}[Covers Units C and D]
 


### PR DESCRIPTION
Hi Robert,
Here's a pull request consisting of the newly-available **\total**\* and **\subtotal***; the following commands can be used
- `\total*`
- `\total*[comment]`
- `\subtotal*`
- `\subtotal*[comment]`

together with their original versions:
- `\total[comment]{2}`
- `\total{2}`
- `\subtotal[comment]{2}`
- `\subtotal{2}`

I've added a small demo section to `tntemplate.tex`.

I hope this is inline with what you were thinking; let me know if you'd like me to change any of it.
Best
Chris
