### PR TITLE
gitignore: added  .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.aux
+*.toc
+*.out
+*.log


### PR DESCRIPTION
Hi Robert,
I thought I'd make this pull request separately; I find that `.gitignore` files are particularly helpful in projects that have latex files involved, as they enable us to ignore the 'cruft' files that `latex` produces (such as .aux, .log, .out, etc). 

This pull request simply creates `.gitignore`. Not sure if this is addition would be welcome? As always, do feel free to reject :)

Best
Chris