### PR TITLE
Bugfix for @update@totals 

### DIFF
--- a/outn.cls
+++ b/outn.cls
@@ -343,8 +343,11 @@
   \afterassignment\get@args\count@=0#1\hfuzz#1\hfuzz}
 \def\get@args#1\hfuzz#2\hfuzz{%
   \if\relax\detokenize{#1}\relax
-     \addtocounter{subtotal}{#2}%
-     \addtocounter{total}{#2}%
+     \if\relax\detokenize{#2}\relax
+     \else
+        \addtocounter{subtotal}{#2}%
+        \addtocounter{total}{#2}%
+     \fi
   \else
     \relax
   \fi


### PR DESCRIPTION
Hi Robert,
This is a very small patch to account for situations such as, for example, `\mk[text]{}`. 

Prior to this commit, the above code would throw an error, as detailed in https://github.com/rbrignall/OU-SUPPS/issues/26. Using this patch, the above code outputs `text` to the margin and no error is thrown.

I hope this is as you like, but all feedback is welcome.
Best
Chris