### PR TITLE
This commit resolves the colouring of the caption command,

### DIFF
--- a/outn.cls
+++ b/outn.cls
@@ -40,6 +40,9 @@
   \RequirePackage{xparse}
 \fi
 \RequirePackage{verbatim}
+\if@specsolns
+  \RequirePackage{caption}
+\fi
 
 
 %%
@@ -77,6 +80,7 @@
 \newcommand\specsolnscolor[1]{\def\@specsolnscolor{#1}}
 \if@specsolns
   \AtBeginDocument{\color{\@specsolnscolor}}
+  \captionsetup{font={color=\@specsolnscolor}}
 \fi
 %
 %


### PR DESCRIPTION
This pull request resolves the colouring of the caption command, reported at:

https://github.com/rbrignall/OU-SUPPS/issues/34

It does so by loading the `caption` package. 

Colouring on a per-caption basis can be achieved (when `specsolns` is active) using the syntax from the caption package, for example:
```
\captionsetup{font={color=black,bf}}
```