### PR TITLE
bug fix to allow exam code to produce barcode in metadataset

### DIFF
--- a/ouexam.cls
+++ b/ouexam.cls
@@ -194,7 +194,7 @@
    session/.estore in =\@session,
    module title/.estore in=\@moduletitle,
    specimen solutions title/.estore in=\@specimensolutionstitle,
-   exam code/.estore in=\@examcode,
+   exam code/.code=\examcode{#1},
    exam time/.estore in =\@examtime,
    exam day/.estore in=\@examday,
    exam month/.estore in=\@exammonth,


### PR DESCRIPTION
The `metadataset` `exam code` key now produces a bar code as expected. 

To test, compare the output from the following file before and after the proposed fix; you should see that the bar code only appears in the pdf with the proposed fix. 
 
```
\documentclass{ouexam} 
\metadataset{
            module code=MST124,
            session=C,
            module title=Title of Module,
            exam code=MST1241706F1PV1,
            exam time={10:00\,am -- 1:00\,pm},
            exam day=Tuesday 7,
            exam month=October,
            exam year=2016,
            time allowed=3 hours,
            copyright year=2016,
            instructions={Insert module-specific examination instructions here},
            }
\begin{document}
\maketitle
\end{document}
```