### PR TITLE
outn.cls bug fix for \mk in align and friends

### DIFF
--- a/outn.cls
+++ b/outn.cls
@@ -514,7 +514,10 @@
 		\@solnmarksbox{#1}{#2}%
 	}	
 	\newcommand{\@@solnmarks}[2][\unskip]{%
-		\@solnmarksbox{#1}{\@update@totals{#2}}%
+          \ifmeasuring@\relax
+          \else
+           \@solnmarksbox{#1}{\@update@totals{#2}}%
+          \fi
 	}
 	\newcommand{\@solnmarksbox}[2]{%
 		\marginnote{\hfill\small\sf %


### PR DESCRIPTION
what is this pull request about? 
-
This resolves https://github.com/rbrignall/OU-SUPPS/issues/98

does this change any existing behaviour?
-
Yes, it fixes the above bug for `subtotal*` and `total*` when `\mk` is used within `align` and friends.

how do I test this?
-
The following file gives the _correct_ `\subtotal*` and `\total*` output with this change. 

```tex
\documentclass{outn}
\metadataset{
 presentation = ddd,
}

\begin{document}

\question{2}
align test:
\begin{align}
 y & = x^2 \mk{1} \\
   & = x^3 \mk{1}
\end{align}

\subtotal*

align* test:
\begin{align*}
 y & = x^2 \mk{1} \\
   & = x^3 \mk{1}
\end{align*}
\subtotal*

gather test:
\begin{gather}
 y = x^2 \mk{1} \\
   = x^3 \mk{1}
\end{gather}
\subtotal*

gather* test:
\begin{gather*}
 y = x^2 \mk{1} \\
   = x^3 \mk{1}
\end{gather*}
\subtotal*

flalign test
\begin{flalign}
 y & = x^2 \mk{1} \\
   & = x^3 \mk{1}
\end{flalign}
\subtotal*

flalign* test
\begin{flalign*}
 y & = x^2 \mk{1} \\
   & = x^3 \mk{1}
\end{flalign*}
\subtotal*

Total:

\total*
\end{document}
```