### PR TITLE
ou-supps test-cases started, with associated GitHub actions and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# 
+# PURPOSE:
+#
+#   keep *github actions* files up to date
+#
+# reference
+#   https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "06:00"
+      timezone: "Europe/London"

--- a/.github/workflows/test-cases-on-develop.yaml
+++ b/.github/workflows/test-cases-on-develop.yaml
@@ -1,0 +1,124 @@
+name: ou-supps run test-cases/ou-supps-test-cases.sh on develop
+# PURPOSE:
+#
+# run 
+# 
+#   ./test-cases/ou-supps-test-cases.sh
+#
+# to produce the test-cases .pdf and .txt files
+# and list any differences from the previous commit
+#
+# Notes: 
+#
+#   (1) this action only runs on DEVELOP branch, there's 
+#       no need to run it on the main branch nor on 
+#       experimental feature branches
+#
+#   (2) this action aims to track, as much as possible, 
+#       if any pdf files within the test-cases directory
+#       are changed
+#
+# references
+#   https://github.com/tj-actions/changed-files
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  check-ou-supps-class-files-changed:
+    name: ou-supps check if ouab.cls outn.cls ouexam.cls ouicma.cls
+    runs-on: ubuntu-latest
+    outputs:
+      anychanged: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get changed files, ou-supps
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            ouab.cls
+            outn.cls
+            ouexam.cls
+            ouicma.cls
+      - if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        name: List all relevant changed files
+        run: |
+          echo ""
+          echo "ou-supps: the following .cls files have changed"
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file has changed since last commit"
+          done
+          echo ""
+      - if: ${{ steps.changed-files.outputs.any_changed == 'false' }}
+        name: No ou-supps class files have changed
+        run: |
+            echo ""
+            echo "none of of the .cls files have changed since last commit"
+            echo "no need to run the rest of test-cases-on-develop.yaml :)"
+            echo ""
+  ou-supps-test-cases:
+    needs: check-ou-supps-class-files-changed
+    if: ${{fromJSON(needs.check-ou-supps-class-files-changed.outputs.anychanged)}}
+    runs-on: ubuntu-latest
+    name: ou-supps-test-cases.sh check as .cls related file(s) changed
+    steps:
+      - name: load the "base actions/checkout" so as to access ou-supps repository
+        uses: actions/checkout@v4
+      #
+      # pdflatex
+      #
+      - name: installing texlive full and producing test-cases/*.pdf files
+        uses: xu-cheng/texlive-action@v2
+        with:
+          scheme: full
+          run: |
+            cp *.cls ./test-cases/
+            cd test-cases/
+            chmod +x ou-supps-test-cases.sh
+            ./ou-supps-test-cases.sh -p
+            echo ""
+            echo "ou-supps: list test-cases/*.pdf"
+            echo ""
+            ls -l *.pdf
+      #
+      # pdftotext
+      #
+      - name: install pdftotext and producing test-cases/*.txt files from pdf
+        run: |
+          sudo apt-get update 
+          sudo apt-get install -y poppler-utils
+          cd test-cases/
+          chmod +x ou-supps-test-cases.sh
+          ./ou-supps-test-cases.sh -t
+          echo ""
+          echo "ou-supps: list test-cases/*.txt"
+          echo ""
+          ls -l *.txt
+      #
+      # check for changes in test-cases/*.txt
+      #
+      - name: Check for changed files in test-cases/*.txt
+        uses: tj-actions/changed-files@v44
+        id: changed-files
+        with:
+          files: |
+            test-cases/*.txt
+      - if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
+        name: List all changed files from test-cases
+        run: |
+          echo ""
+          echo "ou-supps: the following test-cases/*.txt have changed"
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file has changed on this commit"
+          done
+          echo ""
+      - if: ${{ steps.changed-files.outputs.any_changed == 'false' }}
+        name: No test-cases/*.txt files have changed
+        run: |
+            echo ""
+            echo "ou-supps: NONE of test-cases/*.txt have changed on this commit"
+            echo ""

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ OU_Master_Logo_Black_CMYK_29mm.eps
 OU_Master_Logo_Black_CMYK_29mm.pdf
 OU_Master_LOGO_BLACK_17-5mmForA4width.pdf
 OU_Compact_LOGO_BLACK_40mm.pdf
+test-cases/*.pdf

--- a/test-cases/ou-supps-test-cases.sh
+++ b/test-cases/ou-supps-test-cases.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# ou-supps-test-cases.sh
+#
+# a set of files to attempt to track the behaviour of ou-supps
+
+pdflatexMode=0
+pdfToTextMode=0
+while getopts "pt" OPTION
+do
+ case $OPTION in
+   p)
+   pdflatexMode=1
+   ;;
+   t)
+   pdfToTextMode=1
+   ;;
+  esac
+done
+filesToTrack=( 
+    outn-mks-in-align  
+    ouexam-mks-in-align  
+) 
+
+for indvFile in "${filesToTrack[@]}"
+do
+  echo $indvFile
+  [[ $pdflatexMode -eq 1 ]]  && pdflatex --interaction batchmode $indvFile
+  [[ $pdflatexMode -eq 1 ]]  && pdflatex --interaction batchmode $indvFile
+  [[ $pdfToTextMode -eq 1 ]] && pdftotext ${indvFile}.pdf
+done
+exit 0

--- a/test-cases/ouexam-mks-in-align.tex
+++ b/test-cases/ouexam-mks-in-align.tex
@@ -1,0 +1,60 @@
+\documentclass[showsolutions]{ouexam}
+\metadataset{
+ module code= aaa,
+ exam month = bbb,
+ exam year = ccc,
+}
+
+\begin{document}
+
+\question[unit xxx]
+
+\begin{solution}
+align test:
+\begin{align}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{align}
+
+\subtotal*
+
+align* test:
+\begin{align*}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{align*}
+\subtotal*
+
+gather test:
+\begin{gather}
+ y = x^2 \mk{1} \\
+   = x^3 \mk{1}
+\end{gather}
+\subtotal*
+
+gather* test:
+\begin{gather*}
+ y = x^2 \mk{1} \\
+   = x^3 \mk{1}
+\end{gather*}
+\subtotal*
+
+flalign test
+\begin{flalign}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{flalign}
+\subtotal*
+
+flalign* test
+\begin{flalign*}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{flalign*}
+\subtotal*
+
+Total:
+
+\total*
+\end{solution}
+\end{document}

--- a/test-cases/ouexam-mks-in-align.txt
+++ b/test-cases/ouexam-mks-in-align.txt
@@ -1,0 +1,53 @@
+Question 1 unit xxx Solution
+align test: y = x2 = x3
+align* test: y = x2 = x3
+gather test: y = x2 = x3
+gather* test: y = x2 = x3
+flalign test y = x2 = x3
+flalign* test y = x2 = x3
+Total:
+[END OF QUESTION PAPER]
+aaa bbb ccc
+
+(1)
+
+1
+
+(2)
+
+1
+
+2 Subtotal
+
+1 1
+2 Subtotal
+
+(3)
+
+1
+
+(4)
+
+1
+
+2 Subtotal
+
+1 1
+2 Subtotal
+
+(5)
+
+1
+
+(6)
+
+1
+
+2 Subtotal
+
+1 1 2 Subtotal
+12 Total
+
+1
+
+

--- a/test-cases/outn-mks-in-align.tex
+++ b/test-cases/outn-mks-in-align.tex
@@ -1,0 +1,55 @@
+\documentclass{outn}
+\metadataset{
+ presentation = ddd,
+}
+
+\begin{document}
+
+\question{2}
+align test:
+\begin{align}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{align}
+
+\subtotal*
+
+align* test:
+\begin{align*}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{align*}
+\subtotal*
+
+gather test:
+\begin{gather}
+ y = x^2 \mk{1} \\
+   = x^3 \mk{1}
+\end{gather}
+\subtotal*
+
+gather* test:
+\begin{gather*}
+ y = x^2 \mk{1} \\
+   = x^3 \mk{1}
+\end{gather*}
+\subtotal*
+
+flalign test
+\begin{flalign}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{flalign}
+\subtotal*
+
+flalign* test
+\begin{flalign*}
+ y & = x^2 \mk{1} \\
+   & = x^3 \mk{1}
+\end{flalign*}
+\subtotal*
+
+Total:
+
+\total*
+\end{document}

--- a/test-cases/outn-mks-in-align.txt
+++ b/test-cases/outn-mks-in-align.txt
@@ -1,0 +1,25 @@
+Solution to Question 1 ­ 2 marks align test:
+y = x2 = x3
+align* test: y = x2 = x3
+gather test: y = x2 = x3
+gather* test: y = x2 = x3
+flalign test y = x2 = x3
+flalign* test y = x2 = x3
+Total:
+
+(1) 1 (2) 1
+2 Subtotal
+1 1 2 Subtotal
+(3) 1 (4) 1
+2 Subtotal
+1 1 2 Subtotal
+(5) 1 (6) 1
+2 Subtotal
+1 1 2 Subtotal
+12 Total
+
+Copyright © ddd The Open University
+
+page 1 of 1
+
+


### PR DESCRIPTION
what is this pull request about?
=
This pull request introduces `test-cases` to assist us in tracking changes in _output_ from the `ou-supps` class files. 

Importantly, these test cases can be tracked locally, and are also produced and tracked _on every commit_ of the `develop` branch using [GitHub Actions](https://docs.github.com/en/actions/quickstart). 

does this change any existing behaviour?
=
No.

how do I test this?
=
Again, this commit does not _change_ any existing behaviour, the intention is to _track_ a selection of sample output `.pdf` files by converting them to `.txt` files and tracking the differences.

locally
-
Locally, on your own machine, if you perform the following commands from a terminal
```
cd test-cases
./ou-supps-test-cases.sh -p -t
```
then you should see the following output:
```
outn-mks-in-align
This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
ouexam-mks-in-align
This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
```
If you run the commands
```
ls -l *.pdf
ls -l *.txt
```
you should see that the date stamps show that they have been produced by `ou-supps-test-cases.sh`

github actions
-
You can see the output from `github actions` on my fork:
* demonstration of `.pdf` and `.txt` file production within the log files of https://github.com/cmhughes/OU-SUPPS/actions/runs/8749450287

![image](https://github.com/rbrignall/OU-SUPPS/assets/2224480/a24bb0b4-97f4-4d46-903c-2cd67b8acb8e)

* demonstration that the `pdf` and `.txt` file production is _conditional_ and will only trigger if one of the `.cls` files is changed: https://github.com/cmhughes/OU-SUPPS/actions/runs/8749495930

![image](https://github.com/rbrignall/OU-SUPPS/assets/2224480/62043793-2a18-4380-a40e-0961198e21de)


anything else
=
1. Do feel free to reject this if it doesn't look helpful! I'm very happy to chat/discuss if that's helpful. 
2. It feels to me that we need a mechanism to track output files. It's difficult to track changes in `pdf` files, so this proposal uses `pdftotext` to compile a few sample files into `.pdf` and from there, into `.txt` so that we can track the `.txt` files.
3. If you were to accept this, then the intention would be that we would add further files to the `test-cases` directory over time as features are developed and enhanced. The intention would be that this would help us to track that new developments keep the output as stable as possible; I use this approach on other projects, it's a little harder with `ou-supps` as the outputs are `pdf`
4.  [GitHub Actions](https://docs.github.com/en/actions/quickstart) is very powerful, and can be very helpful. If you were to accept this contribution, then you would see the output under the `Actions` tab of your repository
5. You'll see that there is also a file `.github/dependabot.yml` which helps to keep the `,github/workflow` file(s) up to date.